### PR TITLE
Activesupport version prevents use of the gem with rails 4.1.5

### DIFF
--- a/adzerk.gemspec
+++ b/adzerk.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.email         = "engineering@adzerk.com"
   s.homepage      = "http://adzerk.com"
   s.add_development_dependency "rspec", "= 2.11.0"
-  s.add_runtime_dependency "json", "= 1.7.7"
+  s.add_runtime_dependency "json", ">= 1.7.7"
   s.add_runtime_dependency "rest-client", "= 1.6.7"
   s.add_runtime_dependency "activesupport", ">= 3.2.8"
 end

--- a/adzerk.gemspec
+++ b/adzerk.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "= 2.11.0"
   s.add_runtime_dependency "json", "= 1.7.7"
   s.add_runtime_dependency "rest-client", "= 1.6.7"
-  s.add_runtime_dependency "activesupport", "~> 3.2.8"
+  s.add_runtime_dependency "activesupport", ">= 3.2.8"
 end


### PR DESCRIPTION
There was still issue with dependencies for activesupport and json gems, because those two gems' versions were fixed in adzerk.gemspec file. This fix solves the issue and now adzerk-api can be used with latest versions of activesupport and json gems.