### PR TITLE
Improved tests

### DIFF
--- a/test/category_api_spec.rb
+++ b/test/category_api_spec.rb
@@ -86,8 +86,8 @@ describe "Category API" do
   end
 
   it "should list categories for the current network" do
-    cat = @category.listAll()[:items].last
-    expect(cat[:name]).to eq($category_name)
+    cats = @category.listAll()[:items].select { |x| x[:name] == $category_name }
+    expect(cats.count).to eq(1)
   end
 
   it "should delete a category from a flight" do

--- a/test/report_api_spec.rb
+++ b/test/report_api_spec.rb
@@ -36,7 +36,7 @@ describe "Report API" do
   end
 
   it "should return a status of 1 if the report isn't ready yet" do
-    bigger_report = $new_report.update(start_date: "1/1/2010", end_date: "10/1/2014")
+    bigger_report = $new_report.update(start_date: "1/1/2014", end_date: "10/1/2018")
     report_id = @reports.create_queued_report(bigger_report)[:id]
     # immediately poll for the result
     response = @reports.retrieve_queued_report(report_id)


### PR DESCRIPTION
- The category test was checking whether the last category that was
  created was the same as the one it tried to create--this won't work
  in the following case:

  1. Run tests against account.
  2. Add a new category.
  3. Re-run tests.

  The category test will fail because the category create operation will
  succeed without actually creating a new category (because it already
  exists), invalidating the assumption that the category will be the
  last one returned with the get categories request.

- The queued report test was using a date range that was too far in the
  past. If you run the tests without enough data in your account from
  2014 the report will be processed too quickly and the test won't find
  a queued report (it will instead be in the "completed" state).