### PR TITLE
Update tests in 

### DIFF
--- a/test/advertiser_api_spec.rb
+++ b/test/advertiser_api_spec.rb
@@ -62,8 +62,9 @@ describe "Advertiser API" do
     end
   end
 
-  it "should not get individual deleted advertiser" do
-    expect { @advertisers.get $advertiser_id }.to raise_error("This advertiser is deleted.")
+  it "should get individual deleted advertiser" do
+    advertiser = @advertisers.get $advertiser_id
+    expect(advertiser[:is_deleted]).to eq(true)
   end
 
   it "should not update a deleted advertiser" do

--- a/test/channel_api_spec.rb
+++ b/test/channel_api_spec.rb
@@ -82,8 +82,9 @@ describe "Channel API" do
     expect(response.body).to eq('"Successfully deleted"')
   end
 
-  it "should not get individual deleted channel" do
-    expect{ @channels.get($channel_id) }.to raise_error 'This channel has been deleted'
+  it "should get individual deleted channel" do
+    channel = @channels.get $channel_id
+    expect(channel[:is_deleted]).to eq(true)
   end
 
   it "should not update deleted channels" do

--- a/test/creative_map_api_spec.rb
+++ b/test/creative_map_api_spec.rb
@@ -327,8 +327,9 @@ describe "Creative Flight API" do
     expect{ @creative_maps.get(123, @flight_id) }.to raise_error "This flight is not part of your network"
   end
 
-  it "should not get a map that's been deleted" do
-    expect{ @creative_maps.get($map_id, @flight_id) }.to raise_error "This creative map has been deleted"
+  it "should get a map that's been deleted" do
+    map = @creative_maps.get($map_id, @flight_id)
+    expect(map[:is_deleted]).to eq(true)
   end
 
   it "should not update a map that's in a different network" do


### PR DESCRIPTION
preparation for adzerk/adzerk::bugfix-isdeleted-endpoints

The above branch will change the behavior of these endpoints to return deleted
items via get calls.