### PR TITLE
Use ssl when URL protocol is https

### DIFF
--- a/lib/adzerk/client.rb
+++ b/lib/adzerk/client.rb
@@ -9,7 +9,7 @@ module Adzerk
                 :logins, :geotargetings, :sitezonetargetings, :categories
 
     DEFAULTS = {
-      :host => ENV["ADZERK_API_HOST"] || 'http://api.adzerk.net/v1/',
+      :host => ENV["ADZERK_API_HOST"] || 'https://api.adzerk.net/v1/',
       :header => 'X-Adzerk-ApiKey'
     }
 

--- a/lib/adzerk/client.rb
+++ b/lib/adzerk/client.rb
@@ -60,11 +60,11 @@ module Adzerk
       send_request(request, uri)
     end
 
-    def create_creative(data={}, image_path='')      
+    def create_creative(data={}, image_path='')
       response = RestClient.post(@config[:host] + 'creative',
                                  {:creative => camelize_data(data).to_json},
                                  :X_Adzerk_ApiKey => @api_key,
-                                 :content_type => :json, 
+                                 :content_type => :json,
                                  :accept => :json)
       response = upload_creative(JSON.parse(response)["Id"], image_path) unless image_path.empty?
       response
@@ -80,6 +80,7 @@ module Adzerk
 
     def send_request(request, uri)
       http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == 'https'
       response = http.request(request)
       if response.kind_of? Net::HTTPClientError
         error_response = JSON.parse(response.body)

--- a/test/security_api_spec.rb
+++ b/test/security_api_spec.rb
@@ -6,6 +6,7 @@ describe "Channel API security" do
   it "should reject unauthenticated GET requests" do
     uri = URI.parse(API_HOST + 'channel/')
     http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == 'https'
     request = Net::HTTP::Get.new(uri.request_uri)
     expect(http.request(request).response.code).not_to eq(200)
   end
@@ -13,6 +14,7 @@ describe "Channel API security" do
   it "should reject GET requests with null API keys" do
     uri = URI.parse(API_HOST + 'channel/')
     http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == 'https'
     request = Net::HTTP::Get.new(uri.request_uri)
     request.add_field "X-Adzerk-ApiKey", ""
     expect(http.request(request).response.code).not_to eq(200)

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -7,7 +7,7 @@ require "adzerk"
 API_KEY = ENV['ADZERK_API_KEY']
 raise "The ADZERK_API_KEY environment variable must be set." unless API_KEY
 
-API_HOST = ENV['ADZERK_API_HOST'] || 'http://api.adzerk.net/v1/'
+API_HOST = ENV['ADZERK_API_HOST'] || 'https://api.adzerk.net/v1/'
 # $adzerk = Adzerk.new(API_KEY)
 
 RSpec.configure do |config|


### PR DESCRIPTION
By default, this library uses http://api.adzerk.net/v1/ as the API URL, but a different URL can be used by setting the `ADZERK_API_HOST` environment variable.

When setting `ADZERK_API_HOST` to https://api.adzerk.net/v1/, the tests were failing because `use_ssl` wasn't set to true. This fixes that by setting `use_ssl` to true when the URL protocol is https.